### PR TITLE
Only compare non-empty description when filtering rules

### DIFF
--- a/src/main/java/com/dns/resolver/function/DnsResolverFunction.java
+++ b/src/main/java/com/dns/resolver/function/DnsResolverFunction.java
@@ -283,11 +283,13 @@ public class DnsResolverFunction implements Function<DnsResolverInput, String> {
 		if (dnsResolverInput.getRule().equals(DnsResolverConstants.RULE_TYPE_EGRESS)) {
 			return securityGroup.getIpPermissionsEgress().stream()
 					.filter(rule -> rule.getIpv4Ranges().stream()
+							.filter(ipRange -> !StringUtils.isEmpty(ipRange.getDescription()))
 							.anyMatch(ipRange -> ipRange.getDescription()
 									.startsWith(dnsResolverInput.getRuleDescriptionPrefix())))
 					.collect(Collectors.toList());
 		} else {
-			return securityGroup.getIpPermissions().stream().filter(rule -> rule.getIpv4Ranges().stream().anyMatch(
+			return securityGroup.getIpPermissions().stream().filter(rule -> rule.getIpv4Ranges().stream().filter(
+					ipRange -> !StringUtils.isEmpty(ipRange.getDescription())).anyMatch(
 					ipRange -> ipRange.getDescription().startsWith(dnsResolverInput.getRuleDescriptionPrefix())))
 					.collect(Collectors.toList());
 		}


### PR DESCRIPTION
To avoid null pointer exception only compatre non-null descriptions when filtering out IP rules